### PR TITLE
10 - Photo modelling

### DIFF
--- a/app/com/authService/models/Photo.scala
+++ b/app/com/authService/models/Photo.scala
@@ -1,13 +1,9 @@
 package com.authService.models
 
+import com.authService.utils.Profile
 import play.api.libs.json._
-import slick.jdbc.JdbcProfile
 
 import java.time.Instant
-
-trait Profile {
-  val profile: JdbcProfile
-}
 
 case class Photo(
   id: Long,

--- a/app/com/authService/models/Photo.scala
+++ b/app/com/authService/models/Photo.scala
@@ -12,11 +12,11 @@ trait Profile {
 case class Photo(
   id: Long,
   title: String,
-  description: String,
-  source: String,
+  description: Option[String],
+  source: Option[String],
   creator_id: Long,
-  created_at: Instant,
-  updated_at: Instant
+  created_at: Option[Instant],
+  updated_at: Option[Instant]
 )
 
 object Photo {
@@ -29,11 +29,11 @@ trait PhotosTable { this: Profile =>
   class PhotosTableDef(tag: Tag) extends Table[Photo](tag, "photos") {
     def id = column[Long]("id", O.PrimaryKey, O.AutoInc)
     def title = column[String]("title")
-    def description = column[String]("description")
-    def source = column[String]("source")
+    def description = column[Option[String]]("description")
+    def source = column[Option[String]]("source")
     def creator_id = column[Long]("creator_id")
-    def created_at = column[Instant]("created_at")
-    def updated_at = column[Instant]("updated_at")
+    def created_at = column[Option[Instant]]("created_at")
+    def updated_at = column[Option[Instant]]("updated_at")
 
     def * = (
       id,

--- a/app/com/authService/models/Photo.scala
+++ b/app/com/authService/models/Photo.scala
@@ -1,0 +1,50 @@
+package com.authService.models
+
+import play.api.libs.json._
+import slick.jdbc.JdbcProfile
+
+import java.time.Instant
+
+trait Profile {
+  val profile: JdbcProfile
+}
+
+case class Photo(
+  id: Long,
+  title: String,
+  description: String,
+  source: String,
+  creator_id: Long,
+  created_at: Instant,
+  updated_at: Instant
+)
+
+object Photo {
+  implicit val format: Format[Photo] = Json.format[Photo]
+}
+
+trait PhotosTable { this: Profile =>
+  import profile.api._
+
+  class PhotosTableDef(tag: Tag) extends Table[Photo](tag, "photos") {
+    def id = column[Long]("id", O.PrimaryKey, O.AutoInc)
+    def title = column[String]("title")
+    def description = column[String]("description")
+    def source = column[String]("source")
+    def creator_id = column[Long]("creator_id")
+    def created_at = column[Instant]("created_at")
+    def updated_at = column[Instant]("updated_at")
+
+    def * = (
+      id,
+      title,
+      description,
+      source,
+      creator_id,
+      created_at,
+      updated_at
+    ) <> ((Photo.apply _).tupled, Photo.unapply)
+  }
+
+  val photos = TableQuery[PhotosTableDef]
+}

--- a/app/com/authService/models/User.scala
+++ b/app/com/authService/models/User.scala
@@ -1,11 +1,8 @@
 package com.authService.models
 
+import com.authService.utils.Profile
 import play.api.libs.json._
 import slick.jdbc.JdbcProfile
-
-trait Profile {
-  val profile: JdbcProfile
-}
 
 case class User(id: Long, email: String, password: String)
 object User {

--- a/app/com/authService/repositories/PhotoRepository.scala
+++ b/app/com/authService/repositories/PhotoRepository.scala
@@ -1,0 +1,32 @@
+package com.authService.repositories
+
+import com.authService.models._
+import com.authService.utils.{Connection, Profile, SlickDBDriver}
+import com.google.inject.Inject
+import slick.jdbc.JdbcProfile
+
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+class PhotoRepository @Inject() (
+  override val profile: JdbcProfile = SlickDBDriver.getDriver
+) extends PhotosTable
+  with Profile {
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  import profile.api._
+
+  val db = new Connection(profile).db()
+
+  def create(photo: Photo): Future[Photo] = {
+    val insertQuery =
+      photos returning photos.map(_.id) into ((photo, id) => photo.copy(id = id))
+    val action = insertQuery += photo
+
+    db.run(action.asTry).map {
+      case Success(photo: Photo) => photo
+      case Failure(exception: Exception) =>
+        throw new IllegalStateException(exception.getMessage)
+    }
+  }
+}

--- a/app/com/authService/repositories/PhotoRepository.scala
+++ b/app/com/authService/repositories/PhotoRepository.scala
@@ -20,7 +20,9 @@ class PhotoRepository @Inject() (
 
   def create(photo: Photo): Future[Photo] = {
     val insertQuery =
-      photos returning photos.map(_.id) into ((photo, id) => photo.copy(id = id))
+      photos returning photos.map(_.id) into ((photo, id) =>
+        photo.copy(id = id)
+      )
     val action = insertQuery += photo
 
     db.run(action.asTry).map {

--- a/app/com/authService/repositories/UserRepository.scala
+++ b/app/com/authService/repositories/UserRepository.scala
@@ -1,7 +1,7 @@
 package com.authService.repositories
 
 import com.authService.models._
-import com.authService.utils.{Connection, SlickDBDriver}
+import com.authService.utils.{Connection, Profile, SlickDBDriver}
 import com.google.inject.Inject
 import slick.jdbc.JdbcProfile
 

--- a/app/com/authService/utils/Connection.scala
+++ b/app/com/authService/utils/Connection.scala
@@ -1,6 +1,5 @@
 package com.authService.utils
 
-import com.authService.models.Profile
 import com.typesafe.config.ConfigFactory
 import slick.jdbc.JdbcProfile
 

--- a/app/com/authService/utils/SlickDBDriver.scala
+++ b/app/com/authService/utils/SlickDBDriver.scala
@@ -2,6 +2,10 @@ package com.authService.utils
 
 import slick.jdbc.{H2Profile, JdbcProfile, PostgresProfile}
 
+trait Profile {
+  val profile: JdbcProfile
+}
+
 // $COVERAGE-OFF$
 object SlickDBDriver {
   private val TEST = "test"

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ envVars := Map("ENVIRONMENT" -> sys.env.getOrElse("ENVIRONMENT", "production"))
 // Test setup
 Test / fork := true
 Test / envVars := Map("ENVIRONMENT" -> "test")
-Test / flywayUrl := s"jdbc:h2:./test/db/${sys.env.getOrElse("SNAPPY_SHOTS_DB_NAME", "db_name")}_test;MODE=PostgreSQL;DATABASE_TO_UPPER=false"
+Test / flywayUrl := s"jdbc:h2:./test/db/${sys.env.getOrElse("SNAPPY_SHOTS_DB_NAME", "db_name")}_test;MODE=PostgreSQL;DATABASE_TO_UPPER=false;AUTO_SERVER=true"
 Test / flywayUser := "test_user"
 Test / flywayPassword := "test_password"
 Test / flywayLocations := Seq(

--- a/conf/db/migration/snappy_shots/V2__create_photos_tables.sql
+++ b/conf/db/migration/snappy_shots/V2__create_photos_tables.sql
@@ -1,0 +1,9 @@
+CREATE TABLE photos (
+    id SERIAL PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    description VARCHAR(255),
+    creator_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    source VARCHAR(255),
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW()
+);

--- a/conf/test.conf
+++ b/conf/test.conf
@@ -1,4 +1,4 @@
 db.driver="org.h2.Driver"
-db.url="jdbc:h2:./test/db/"${?SNAPPY_SHOTS_DB_NAME}"_test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;DB_CLOSE_ON_EXIT=FALSE;AUTO_SERVER=TRUE;LOCK_TIMEOUT=60000"
+db.url="jdbc:h2:./test/db/"${?SNAPPY_SHOTS_DB_NAME}"_test;MODE=PostgreSQL;DATABASE_TO_UPPER=false;AUTO_SERVER=TRUE;"
 db.username="test_user"
 db.password="test_password"

--- a/test/com/authService/AsyncUnitSpec.scala
+++ b/test/com/authService/AsyncUnitSpec.scala
@@ -1,7 +1,7 @@
 package com.authService
 
 import org.scalamock.scalatest.AsyncMockFactory
-import org.scalatest.BeforeAndAfterEach
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import org.scalatest.funspec.AsyncFunSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -9,4 +9,5 @@ abstract class AsyncUnitSpec
   extends AsyncFunSpec
   with AsyncMockFactory
   with BeforeAndAfterEach
+  with BeforeAndAfterAll
   with Matchers

--- a/test/com/authService/DbUnitSpec.scala
+++ b/test/com/authService/DbUnitSpec.scala
@@ -1,0 +1,24 @@
+package com.authService
+
+import com.authService.utils.{Connection, SlickDBDriver}
+import org.scalatest.concurrent.ScalaFutures
+
+class DbUnitSpec extends AsyncUnitSpec with ScalaFutures {
+  protected val profile = SlickDBDriver.getDriver
+
+  protected val db = new Connection(profile).db()
+
+  override def beforeEach(): Unit = {
+    val session = db.createSession()
+    session.createStatement().execute("SET REFERENTIAL_INTEGRITY TO FALSE");
+    session.createStatement().execute("TRUNCATE TABLE \"users\" RESTART IDENTITY");
+    session.createStatement().execute("ALTER TABLE \"users\" ALTER COLUMN \"id\" RESTART WITH 1");
+    session.createStatement().execute("TRUNCATE TABLE \"photos\" RESTART IDENTITY");
+    session.createStatement().execute("ALTER TABLE \"photos\" ALTER COLUMN \"id\" RESTART WITH 1");
+    session.createStatement().execute("SET REFERENTIAL_INTEGRITY TO TRUE");
+  }
+
+  override def afterAll(): Unit = {
+    db.close()
+  }
+}

--- a/test/com/authService/DbUnitSpec.scala
+++ b/test/com/authService/DbUnitSpec.scala
@@ -11,10 +11,18 @@ class DbUnitSpec extends AsyncUnitSpec with ScalaFutures {
   override def beforeEach(): Unit = {
     val session = db.createSession()
     session.createStatement().execute("SET REFERENTIAL_INTEGRITY TO FALSE");
-    session.createStatement().execute("TRUNCATE TABLE \"users\" RESTART IDENTITY");
-    session.createStatement().execute("ALTER TABLE \"users\" ALTER COLUMN \"id\" RESTART WITH 1");
-    session.createStatement().execute("TRUNCATE TABLE \"photos\" RESTART IDENTITY");
-    session.createStatement().execute("ALTER TABLE \"photos\" ALTER COLUMN \"id\" RESTART WITH 1");
+    session
+      .createStatement()
+      .execute("TRUNCATE TABLE \"users\" RESTART IDENTITY");
+    session
+      .createStatement()
+      .execute("ALTER TABLE \"users\" ALTER COLUMN \"id\" RESTART WITH 1");
+    session
+      .createStatement()
+      .execute("TRUNCATE TABLE \"photos\" RESTART IDENTITY");
+    session
+      .createStatement()
+      .execute("ALTER TABLE \"photos\" ALTER COLUMN \"id\" RESTART WITH 1");
     session.createStatement().execute("SET REFERENTIAL_INTEGRITY TO TRUE");
   }
 

--- a/test/com/authService/repositories/PhotoRepositorySpec.scala
+++ b/test/com/authService/repositories/PhotoRepositorySpec.scala
@@ -1,0 +1,65 @@
+package com.authService.repositories
+
+import com.authService.AsyncUnitSpec
+import com.authService.models.Photo
+import com.authService.utils.{Connection, SlickDBDriver}
+import org.scalatest.concurrent.ScalaFutures
+
+import java.time.Instant
+import scala.util.Failure
+import scala.util.control.Exception
+
+class PhotoRepositorySpec extends AsyncUnitSpec with ScalaFutures {
+  val repository = new PhotoRepository
+
+  val profile = SlickDBDriver.getDriver
+  val db = new Connection(profile).db()
+  import profile.api._
+
+  override def beforeEach(): Unit = {
+  }
+
+  describe("#create") {
+    val mockPhoto = Photo(
+      id = 0,
+      title = "My wonderful photo",
+      creator_id = 1,
+      description = None,
+      source = None,
+      created_at = Some(Instant.now()),
+      updated_at = Some(Instant.now())
+    )
+
+    describe("on success") {
+      it("should create a photo") {
+        val createUserAction = sqlu"""INSERT INTO users (id, email, password) VALUES(1, 'foo@bar.com', 'password')"""
+        val createUserQuery = db.run(createUserAction)
+
+        for {
+          _ <- createUserQuery
+          photo <- repository.create(mockPhoto)
+        } yield photo match {
+          case photo =>
+            assert(photo.id == 1)
+            assert(photo.title == mockPhoto.title)
+        }
+      }
+    }
+
+    describe("on failure") {
+      it("should throw an exception") {
+        val createUserAction = sqlu"""DELETE FROM users WHERE id = 1"""
+        val createUserQuery = db.run(createUserAction)
+
+        val query = for {
+          _ <- createUserQuery
+          response <- repository.create(mockPhoto)
+        } yield response
+
+        recoverToExceptionIf[Exception](query).map { result =>
+          result.getMessage should include("Referential integrity constraint violation")
+        }
+      }
+    }
+  }
+}

--- a/test/com/authService/repositories/PhotoRepositorySpec.scala
+++ b/test/com/authService/repositories/PhotoRepositorySpec.scala
@@ -23,7 +23,8 @@ class PhotoRepositorySpec extends DbUnitSpec {
 
     describe("on success") {
       it("should create a photo") {
-        val createUserAction = sqlu"""INSERT INTO users (id, email, password) VALUES(1, 'foo@bar.com', 'password')"""
+        val createUserAction =
+          sqlu"""INSERT INTO users (id, email, password) VALUES(1, 'foo@bar.com', 'password')"""
         val createUserQuery = db.run(createUserAction)
 
         for {
@@ -48,7 +49,9 @@ class PhotoRepositorySpec extends DbUnitSpec {
         } yield response
 
         recoverToExceptionIf[Exception](query).map { result =>
-          result.getMessage should include("Referential integrity constraint violation")
+          result.getMessage should include(
+            "Referential integrity constraint violation"
+          )
         }
       }
     }

--- a/test/com/authService/repositories/PhotoRepositorySpec.scala
+++ b/test/com/authService/repositories/PhotoRepositorySpec.scala
@@ -1,23 +1,14 @@
 package com.authService.repositories
 
-import com.authService.AsyncUnitSpec
+import com.authService.DbUnitSpec
 import com.authService.models.Photo
-import com.authService.utils.{Connection, SlickDBDriver}
-import org.scalatest.concurrent.ScalaFutures
 
 import java.time.Instant
-import scala.util.Failure
-import scala.util.control.Exception
 
-class PhotoRepositorySpec extends AsyncUnitSpec with ScalaFutures {
+class PhotoRepositorySpec extends DbUnitSpec {
   val repository = new PhotoRepository
 
-  val profile = SlickDBDriver.getDriver
-  val db = new Connection(profile).db()
   import profile.api._
-
-  override def beforeEach(): Unit = {
-  }
 
   describe("#create") {
     val mockPhoto = Photo(

--- a/test/com/authService/repositories/UserRepositorySpec.scala
+++ b/test/com/authService/repositories/UserRepositorySpec.scala
@@ -1,10 +1,9 @@
 package com.authService.repositories
 
-import com.authService.AsyncUnitSpec
+import com.authService.DbUnitSpec
 import com.authService.models.User
-import org.scalatest.concurrent.ScalaFutures
 
-class UserRepositorySpec extends AsyncUnitSpec with ScalaFutures {
+class UserRepositorySpec extends DbUnitSpec {
   val repository = new UserRepository
 
   describe("#addUser") {
@@ -12,14 +11,11 @@ class UserRepositorySpec extends AsyncUnitSpec with ScalaFutures {
       it("should add a user") {
         val subject =
           repository.addUser(User(0, "test_one@test.com", "password"))
+
         subject
           .map { user =>
             assert(user.id == 1)
             assert(user.email == "test_one@test.com")
-          }
-          .recover { case e: Exception =>
-            println("FAILED TO ADD USER:\n" + e.getMessage)
-            fail(e)
           }
       }
     }
@@ -38,10 +34,10 @@ class UserRepositorySpec extends AsyncUnitSpec with ScalaFutures {
   describe("#getUser") {
     it("should return the user") {
       for {
-        _ <- repository.addUser(User(0, "test_two@test.com", "password"))
-        result <- repository.getUser(3)
+        _ <- repository.addUser(User(0, "test_one@test.com", "password"))
+        result <- repository.getUser(1)
       } yield result match {
-        case Some(user) => assert(user.email == "test_two@test.com")
+        case Some(user) => assert(user.email == "test_one@test.com")
       }
     }
   }


### PR DESCRIPTION
- Create photos table
- Photo model
- Make some Photo columns optional
  - source - because this will get added later once a photo is uploaded.
  - description - because this just shouldn't be required for every photo.
  - created_at and updated_at - because I want SQL to manage these values, not Slick.
- Move db Profile to SlickDbDriver class
- PhotoRepository#create
  - mostly just adding this to check the models are setup correctly to work with a repository. I will add the remaining repository methods in a later PR.
- Delete all tables before each spec
  - I originally tried doing this by running a slick query, but that was doing it async and not creating a blocking thread. The way it is now, it runs before the specs, so we have referential integrity for primary keys. It might get a bit unwieldy if the table count gets very high, but lets handle that if / when it happens.
